### PR TITLE
v1.1.3

### DIFF
--- a/Assets/CustomWorldBootstrap.cs
+++ b/Assets/CustomWorldBootstrap.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * v1.1.2
+ * v1.1.3
  * */
 
 using CustomWorldBoostrapInternal;
@@ -15,6 +15,7 @@ public abstract class CustomWorldBootstrap : ICustomBootstrap, ICustomWorldBoots
     /// Per world options
     /// </summary>
     public List<WorldOption> WorldOptions { get; } = new List<WorldOption>();
+
     /// <summary>
     /// Set false to disable the default world creation
     /// </summary>

--- a/Assets/CustomWorldBootstrap.cs
+++ b/Assets/CustomWorldBootstrap.cs
@@ -251,7 +251,7 @@ namespace CustomWorldBoostrapInternal
                 }
                 else
                 {
-                    data.World.GetOrCreateSystem<SimulationSystemGroup>().AddSystemToUpdateList(data.World.GetExistingSystem(createdSystemType));
+                    World.Active.GetOrCreateSystem<SimulationSystemGroup>().AddSystemToUpdateList(data.World.GetExistingSystem(createdSystemType));
                 }
             }
         }

--- a/Assets/CustomWorldBootstrap.cs
+++ b/Assets/CustomWorldBootstrap.cs
@@ -180,7 +180,6 @@ namespace CustomWorldBoostrapInternal
 
         private void InitialiseEachWorld(List<Type> systems)
         {
-            var defaultSystemTypes = GetDefaultSystemTypes(systems);
 
             foreach (var data in WorldData.Values)
             {

--- a/Assets/CustomWorldBootstrap.cs
+++ b/Assets/CustomWorldBootstrap.cs
@@ -260,7 +260,7 @@ namespace CustomWorldBoostrapInternal
         {
             foreach (World w in WorldData.Select(x => x.Value.World))
             {
-                ScriptBehaviourUpdateOrder.UpdatePlayerLoop(w);
+                //ScriptBehaviourUpdateOrder.UpdatePlayerLoop(w);
                 if (WorldData.Select(x => x.Value.Options).Where(x => x.Name == w.Name).FirstOrDefault().OnInitialize != null)
                 {
                     WorldData.Select(x => x.Value.Options).Where(x => x.Name == w.Name).FirstOrDefault().OnInitialize.Invoke(w);

--- a/Assets/CustomWorldBootstrap.cs
+++ b/Assets/CustomWorldBootstrap.cs
@@ -233,10 +233,13 @@ namespace CustomWorldBoostrapInternal
                     {
                         throw new Exception(string.Format("System {0} is trying to update in a non ComponentSystemGroup class", createdSystemType.Name));
                     }
-                    if (data.WorldSystems.Contains(updateInGroupType)
-                        || updateInGroupType == typeof(InitializationSystemGroup)
+                    if (updateInGroupType == typeof(InitializationSystemGroup)
                         || updateInGroupType == typeof(SimulationSystemGroup)
                         || updateInGroupType == typeof(PresentationSystemGroup))
+                    {
+                        (World.Active.GetOrCreateSystem(updateInGroupType) as ComponentSystemGroup).AddSystemToUpdateList(data.World.GetOrCreateSystem(createdSystemType));
+                    }
+                    else if (data.WorldSystems.Contains(updateInGroupType))
                     {
                         (data.World.GetOrCreateSystem(updateInGroupType) as ComponentSystemGroup).AddSystemToUpdateList(data.World.GetOrCreateSystem(createdSystemType));
                     }

--- a/Assets/CustomWorldBootstrap.cs
+++ b/Assets/CustomWorldBootstrap.cs
@@ -156,7 +156,9 @@ namespace CustomWorldBoostrapInternal
         private void PopulateWorldOptions(List<Type> systems)
         {
             var customWorldNames = systems
-                .Where(x => x.CustomAttributes.Any(n => n.AttributeType.Name == nameof(CreateInWorldAttribute)))
+                .Where(x =>
+                x.CustomAttributes.Any(n => n.AttributeType.Name == nameof(CreateInWorldAttribute)) &&
+                x.CustomAttributes.Where(n => n.AttributeType.Name == nameof(CreateInWorldAttribute)).First().ConstructorArguments.Count > 0)
                 .Select(x => x.CustomAttributes
                     .Where(n => n.AttributeType.Name == nameof(CreateInWorldAttribute))
                     .FirstOrDefault().ConstructorArguments[0].ToString().Trim('"'))

--- a/Assets/TestImplementations.meta
+++ b/Assets/TestImplementations.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9061dfe05cb394b44a6ec865303b1902
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/DefaultWorldTests.cs
+++ b/Assets/Tests/DefaultWorldTests.cs
@@ -1,5 +1,7 @@
-﻿using NUnit.Framework;
-using CustomWorldBoostrapInternal;
+﻿using CustomWorldBoostrapInternal;
+using NUnit.Framework;
+using Unity.Entities;
+using System.Linq;
 
 namespace Tests
 {
@@ -26,6 +28,35 @@ namespace Tests
             m_DefaultSystems.Add(typeof(Test1));
             var newSystems = new Initialiser(m_FakeCWB).Initialise(m_DefaultSystems);
             Assert.Contains(typeof(Test1), newSystems);
+        }
+
+        [Test]
+        public void Should_Create_A_New_Default_World_With_10_Default_Systems()
+        {
+            new Initialiser(
+                m_FakeCWB,
+                true,
+                new System.Collections.Generic.List<CustomWorldBootstrap.WorldOption> {
+                    new CustomWorldBootstrap.WorldOption("Test A")
+                },
+                "Test A")
+                .Initialise(m_DefaultSystems);
+            Assert.IsTrue(World.AllWorlds.Any(x=>x.Name=="Test A"));
+            Assert.AreSame("Test A", World.Active.Name);
+            Assert.AreEqual(10, World.Active.Systems.Count());
+        }
+
+        [Test]
+        public void Should_Return_Null_When_Creating_A_New_Default_World()
+        {
+            Assert.IsNull(new Initialiser(
+                m_FakeCWB,
+                true,
+                new System.Collections.Generic.List<CustomWorldBootstrap.WorldOption> {
+                    new CustomWorldBootstrap.WorldOption("Test A")
+                },
+                "Test A")
+                .Initialise(m_DefaultSystems));
         }
     }
 }

--- a/Assets/Tests/EmptyWorldTests.cs
+++ b/Assets/Tests/EmptyWorldTests.cs
@@ -34,7 +34,7 @@ namespace Tests
         [Test]
         public void World_Is_Has_No_NonDefault_Systems()
         {
-            Assert.IsEmpty(GetWorld(WORLDNAME).Systems.Where(x => !m_InitialSystems.Contains(x.GetType())));
+            Assert.IsEmpty(GetWorld(WORLDNAME).Systems);
         }
     }
 }

--- a/Assets/Tests/Resources/TestComponentSystems.cs
+++ b/Assets/Tests/Resources/TestComponentSystems.cs
@@ -28,7 +28,6 @@ namespace Tests
 
     }
 
-
     [DisableAutoCreation]
     [UpdateInGroup(typeof(InitializationSystemGroup))]
     [CreateInWorld("Test3 World")]
@@ -36,6 +35,7 @@ namespace Tests
     {
 
     }
+
     [DisableAutoCreation]
     [UpdateInGroup(typeof(SimulationSystemGroup))]
     [CreateInWorld("Test3 World")]
@@ -43,6 +43,7 @@ namespace Tests
     {
 
     }
+
     [DisableAutoCreation]
     [UpdateInGroup(typeof(PresentationSystemGroup))]
     [CreateInWorld("Test3 World")]
@@ -65,7 +66,6 @@ namespace Tests
     {
 
     }
-
 
     [DisableAutoCreation]
     [CreateInWorld("Test5 World")]

--- a/Assets/Tests/SingleSystemTests.cs
+++ b/Assets/Tests/SingleSystemTests.cs
@@ -32,7 +32,7 @@ namespace Tests
         public void System_Updates_In_Default_UpdateGroup()
         {
             var world =GetWorld(WORLDNAME);
-            world.GetExistingSystem<SimulationSystemGroup>().Update();
+            World.Active.GetExistingSystem<SimulationSystemGroup>().Update();
             Assert.IsTrue(world.GetExistingSystem<Test2>().Updated);
         }
     }

--- a/Assets/Tests/SystemInGroupTests.cs
+++ b/Assets/Tests/SystemInGroupTests.cs
@@ -42,7 +42,7 @@ namespace Tests
         {
             var world = GetWorld(WORLDNAME);
 
-            world.GetExistingSystem<SimulationSystemGroup>().Update();
+            World.Active.GetExistingSystem<SimulationSystemGroup>().Update();
             Assert.IsTrue(world.GetExistingSystem<Test4_System>().Updated);
         }
     }

--- a/Assets/Tests/UpdateInGroupTests.cs
+++ b/Assets/Tests/UpdateInGroupTests.cs
@@ -54,7 +54,7 @@ namespace Tests
             simSys.Updated = false;
             presSys.Updated = false;
 
-            world.GetExistingSystem<InitializationSystemGroup>().Update();
+            World.Active.GetExistingSystem<InitializationSystemGroup>().Update();
 
             Assert.IsTrue(world.GetExistingSystem<Test3_InitializationSystem>().Updated);
             Assert.IsFalse(world.GetExistingSystem<Test3_SimulationSystem>().Updated);
@@ -73,7 +73,7 @@ namespace Tests
             simSys.Updated = false;
             presSys.Updated = false;
 
-            world.GetExistingSystem<SimulationSystemGroup>().Update();
+            World.Active.GetExistingSystem<SimulationSystemGroup>().Update();
 
             Assert.IsFalse(world.GetExistingSystem<Test3_InitializationSystem>().Updated);
             Assert.IsTrue(world.GetExistingSystem<Test3_SimulationSystem>().Updated);
@@ -92,7 +92,7 @@ namespace Tests
             simSys.Updated = false;
             presSys.Updated = false;
 
-            world.GetExistingSystem<PresentationSystemGroup>().Update();
+            World.Active.GetExistingSystem<PresentationSystemGroup>().Update();
 
             Assert.IsFalse(world.GetExistingSystem<Test3_InitializationSystem>().Updated);
             Assert.IsFalse(world.GetExistingSystem<Test3_SimulationSystem>().Updated);

--- a/Assets/Tests/UpdateInTeir2GroupTests.cs
+++ b/Assets/Tests/UpdateInTeir2GroupTests.cs
@@ -45,7 +45,7 @@ namespace Tests
         public void System_Updates_In_UpdateGroup()
         {
             var world = GetWorld(WORLDNAME);
-            world.GetExistingSystem<SimulationSystemGroup>().Update();
+            World.Active.GetExistingSystem<SimulationSystemGroup>().Update();
             Assert.IsTrue(world.GetExistingSystem<Test5_System>().Updated);
         }
     }

--- a/README.md
+++ b/README.md
@@ -3,13 +3,18 @@
 </a>
 
 # CustomWorldBootstrap
-### v1.1.2 Changes
+**v1.1.3 Changes**
+[See pull request #31](pull/31)
+
+**v1.1.2 Changes**
 * Fixed an issue where WorldOptions was not initialized
-### v1.1.1 Changes
+
+**v1.1.1 Changes**
 * WorldOption is now located in CustomWorldBootstrap class.
 *Previously it was erronously put in global and CustomWorldBootstrapInternal namespaces. If you have referenced it in these namespaces it will now be marked as obsolete*
 * Code tidy up done cleaning up unused usings and unnecessary whitespace
 * Some small refactoring changes
+
 ## Files
 Copy the following files into your unity project
 


### PR DESCRIPTION
Removed incorrect usage of UpdateInPlayerLoop (Closes #33 )
Now adding to base SystemGroups in default world (Closes #32)
Updated tests to test systems update in default world update groups.
Added option to change the default world (which removes transform/sub-scene systems)
Fixed possible error on using attribute with no world name
Removed unused variable 
Version bump 