### PR TITLE
v1.2

### DIFF
--- a/Assets/CustomWorldBootstrap.cs
+++ b/Assets/CustomWorldBootstrap.cs
@@ -275,21 +275,24 @@ namespace CustomWorldBoostrapInternal
                     {
                         throw new Exception(string.Format("System {0} is trying to update in a non ComponentSystemGroup class", createdSystemType.Name));
                     }
+                    ComponentSystemGroup updateGroup;
                     if (updateInGroupType == typeof(InitializationSystemGroup)
                         || updateInGroupType == typeof(SimulationSystemGroup)
                         || updateInGroupType == typeof(PresentationSystemGroup))
                     {
-                        (World.Active.GetOrCreateSystem(updateInGroupType) as ComponentSystemGroup).AddSystemToUpdateList(data.World.GetOrCreateSystem(createdSystemType));
+                        updateGroup = (ComponentSystemGroup)World.Active.GetOrCreateSystem(updateInGroupType);
                     }
                     else if (data.WorldSystems.Contains(updateInGroupType))
                     {
-                        (data.World.GetOrCreateSystem(updateInGroupType) as ComponentSystemGroup).AddSystemToUpdateList(data.World.GetOrCreateSystem(createdSystemType));
+                        updateGroup = (ComponentSystemGroup)data.World.GetOrCreateSystem(updateInGroupType);
                     }
                     else
                     {
                         Debug.LogWarning(string.Format("Tried to create system {0} in {1} that doesn't exist. Updating in simulation group", createdSystemType.Name, updateInGroupType.Name));
-                        data.World.GetOrCreateSystem<SimulationSystemGroup>().AddSystemToUpdateList(data.World.GetOrCreateSystem(createdSystemType));
+                        updateGroup = data.World.GetOrCreateSystem<SimulationSystemGroup>();
                     }
+                    updateGroup.AddSystemToUpdateList(data.World.GetOrCreateSystem(createdSystemType));
+                    updateGroup.SortSystemUpdateList();
                 }
                 else
                 {

--- a/Assets/CustomWorldBootstrap.cs
+++ b/Assets/CustomWorldBootstrap.cs
@@ -26,11 +26,11 @@ public abstract class CustomWorldBootstrap : ICustomBootstrap, ICustomWorldBoots
 
     /// <summary>
     /// Name of world to assign as default world
-    /// Changing this will change the default world
+    /// Setting this will change the default world
     /// The new default world will not have any additional systems
     /// such as the ones for hybrid and sub scenes
     /// </summary>
-    public string DefaultWorldName = "Default World";
+    public string DefaultWorldName = "";
 
     /// <summary>
     /// Accessor for the default world, null if CreateDefaultWorld = false
@@ -49,7 +49,7 @@ public abstract class CustomWorldBootstrap : ICustomBootstrap, ICustomWorldBoots
         {
             if (m_Initialiser == null)
             {
-                m_Initialiser = new Initialiser(this, CreateDefaultWorld, WorldOptions);
+                m_Initialiser = new Initialiser(this, CreateDefaultWorld, WorldOptions, DefaultWorldName == "" ? "Default World" : DefaultWorldName);
             }
             return m_Initialiser;
         }

--- a/Assets/CustomWorldBootstrap.cs
+++ b/Assets/CustomWorldBootstrap.cs
@@ -91,7 +91,7 @@ public abstract class CustomWorldBootstrap : ICustomBootstrap, ICustomWorldBoots
         /// The systems returned will be created in this world
         ///  and will not be created in default world
         /// </summary>
-        public Func<List<Type>, List<Type>> CustomIncludeFilter;
+        public Func<List<Type>, List<Type>> CustomIncludeQuery;
 
         public WorldOption(string name)
         {
@@ -240,9 +240,9 @@ namespace CustomWorldBoostrapInternal
                  * Create systems in the world
                  */
                 data.WorldSystems = GetSystemTypesIncludingUpdateInGroupAncestors(data.Options.Name, systems).ToList();
-                if(data.Options.CustomIncludeFilter!=null)
+                if(data.Options.CustomIncludeQuery!=null)
                 {
-                    data.WorldSystems.AddRange(data.Options.CustomIncludeFilter(systems));
+                    data.WorldSystems.AddRange(data.Options.CustomIncludeQuery(systems));
                     data.WorldSystems = data.WorldSystems.Distinct().ToList();
                 }
                 foreach (var worldSystemType in data.WorldSystems)

--- a/Assets/CustomWorldBootstrap.cs
+++ b/Assets/CustomWorldBootstrap.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * v1.1.3
+ * v1.2.0
  * */
 
 using CustomWorldBoostrapInternal;

--- a/Assets/CustomWorldBootstrap.cs
+++ b/Assets/CustomWorldBootstrap.cs
@@ -22,7 +22,7 @@ public abstract class CustomWorldBootstrap : ICustomBootstrap, ICustomWorldBoots
     /// will need updating manually, and there will be no default buffer systems - creating them will
     /// not mean they update in the expected order.
     /// </summary>
-    public bool CreateDefaultWorld = true;
+    public bool CreateDefaultWorld { get; set; } = true;
 
     /// <summary>
     /// Name of world to assign as default world
@@ -30,7 +30,7 @@ public abstract class CustomWorldBootstrap : ICustomBootstrap, ICustomWorldBoots
     /// The new default world will not have any additional systems
     /// such as the ones for hybrid and sub scenes
     /// </summary>
-    public string DefaultWorldName = "";
+    public string DefaultWorldName { get; set; } = "";
 
     /// <summary>
     /// Accessor for the default world, null if CreateDefaultWorld = false
@@ -49,7 +49,7 @@ public abstract class CustomWorldBootstrap : ICustomBootstrap, ICustomWorldBoots
         {
             if (m_Initialiser == null)
             {
-                m_Initialiser = new Initialiser(this, CreateDefaultWorld, WorldOptions, DefaultWorldName == "" ? "Default World" : DefaultWorldName);
+                m_Initialiser = new Initialiser(this);
             }
             return m_Initialiser;
         }
@@ -129,20 +129,19 @@ namespace CustomWorldBoostrapInternal
             public CustomWorldBootstrap.WorldOption Options;
         }
 
-        public Initialiser(ICustomWorldBootstrap customWorldBootstrap, bool createDefaultWorld = true, List<CustomWorldBootstrap.WorldOption> worldOptions = null, string defaultWorldName = "Default World")
+        public Initialiser(ICustomWorldBootstrap customWorldBootstrap)
         {
             WorldData = new Dictionary<string, WorldInfo>();
-            if (worldOptions != null)
+
+            foreach (var wo in customWorldBootstrap.WorldOptions)
             {
-                foreach (var wo in worldOptions)
-                {
-                    WorldData.Add(wo.Name, new WorldInfo() { Options = wo });
-                }
+                WorldData.Add(wo.Name, new WorldInfo() { Options = wo });
             }
+
             CustomWorlds = new Dictionary<string, World>();
             m_CustomWorldBootstrap = customWorldBootstrap;
-            m_CreateDefaultWorld = createDefaultWorld;
-            m_DefaultWorldName = defaultWorldName;
+            m_CreateDefaultWorld = customWorldBootstrap.CreateDefaultWorld;
+            m_DefaultWorldName = customWorldBootstrap.DefaultWorldName == "" ? m_DefaultWorldName : customWorldBootstrap.DefaultWorldName;
         }
 
         public List<Type> Initialise(List<Type> systems)
@@ -409,6 +408,9 @@ namespace CustomWorldBoostrapInternal
 
     public interface ICustomWorldBootstrap
     {
+        bool CreateDefaultWorld { get; set; }
+        string DefaultWorldName { get; set; }
+        List<CustomWorldBootstrap.WorldOption> WorldOptions { get; }
         List<Type> PostInitialize(List<Type> systems);
     }
 

--- a/Assets/Tests/CustomIncludeTests.cs
+++ b/Assets/Tests/CustomIncludeTests.cs
@@ -1,0 +1,42 @@
+using CustomWorldBoostrapInternal;
+using NUnit.Framework;
+using Unity.Burst;
+using Unity.Entities;
+using UnityEditor;
+using UnityEngine;
+using System.Linq;
+
+namespace Tests
+{
+    public class CustomIncludeTests : MyTestFixture
+    {
+        private const string WORLDNAME = "Test7 World";
+
+        [OneTimeSetUp]
+        protected override void OneTimeSetup()
+        {
+            base.OneTimeSetup();
+            m_DefaultSystems.Add(typeof(Test7_System));
+            new Initialiser(
+                m_FakeCWB,
+                true,
+                new System.Collections.Generic.List<CustomWorldBootstrap.WorldOption>() {
+                    new CustomWorldBootstrap.WorldOption(WORLDNAME) {
+                        CustomIncludeFilter = systems=>systems
+                        .Where(system=>system.GetInterfaces().Any(iface=>iface.Name== nameof(ITest7))).ToList()
+                    }
+                }).Initialise(m_DefaultSystems);
+        }
+
+        [Test]
+        public void Should_Have_Test7_World()
+        {
+            Assert.IsTrue(World.AllWorlds.Any(w=>w.Name==WORLDNAME));
+        }
+        [Test]
+        public void Should_Have_Test7_System_In_Test7_World()
+        {
+            Assert.IsTrue(World.AllWorlds.Where(w => w.Name == WORLDNAME).First().Systems.Any(sys=>sys.GetType().Name==nameof(Test7_System)));
+        }
+    }
+}

--- a/Assets/Tests/CustomIncludeTests.cs
+++ b/Assets/Tests/CustomIncludeTests.cs
@@ -18,14 +18,12 @@ namespace Tests
             base.OneTimeSetup();
             m_DefaultSystems.Add(typeof(Test7_System));
             new Initialiser(
-                m_FakeCWB,
-                true,
-                new System.Collections.Generic.List<CustomWorldBootstrap.WorldOption>() {
+                new FakeCustomWorldBootstrap(new System.Collections.Generic.List<CustomWorldBootstrap.WorldOption>() {
                     new CustomWorldBootstrap.WorldOption(WORLDNAME) {
                         CustomIncludeQuery = systems=>systems
                         .Where(system=>system.GetInterfaces().Any(iface=>iface.Name== nameof(ITest7))).ToList()
                     }
-                }).Initialise(m_DefaultSystems);
+                })).Initialise(m_DefaultSystems);
         }
 
         [Test]

--- a/Assets/Tests/CustomIncludeTests.cs
+++ b/Assets/Tests/CustomIncludeTests.cs
@@ -22,7 +22,7 @@ namespace Tests
                 true,
                 new System.Collections.Generic.List<CustomWorldBootstrap.WorldOption>() {
                     new CustomWorldBootstrap.WorldOption(WORLDNAME) {
-                        CustomIncludeFilter = systems=>systems
+                        CustomIncludeQuery = systems=>systems
                         .Where(system=>system.GetInterfaces().Any(iface=>iface.Name== nameof(ITest7))).ToList()
                     }
                 }).Initialise(m_DefaultSystems);

--- a/Assets/Tests/DefaultWorldTests.cs
+++ b/Assets/Tests/DefaultWorldTests.cs
@@ -1,7 +1,7 @@
 ﻿using CustomWorldBoostrapInternal;
 using NUnit.Framework;
-using Unity.Entities;
 using System.Linq;
+using Unity.Entities;
 
 namespace Tests
 {
@@ -18,7 +18,7 @@ namespace Tests
         [Test]
         public void Setting_CreateDefaultWorld_False_Produces_Null()
         {
-            var init = new Initialiser(m_FakeCWB, false);
+            var init = new Initialiser(new FakeCustomWorldBootstrap(null, false));
             Assert.IsNull(init.Initialise(DefaultSystems));
         }
 
@@ -34,14 +34,15 @@ namespace Tests
         public void Should_Create_A_New_Default_World_With_10_Default_Systems()
         {
             new Initialiser(
-                m_FakeCWB,
-                true,
-                new System.Collections.Generic.List<CustomWorldBootstrap.WorldOption> {
-                    new CustomWorldBootstrap.WorldOption("Test A")
-                },
-                "Test A")
+                new FakeCustomWorldBootstrap(
+                     new System.Collections.Generic.List<CustomWorldBootstrap.WorldOption> {
+                        new CustomWorldBootstrap.WorldOption("Test A")
+                     },
+                     true,
+                     "Test A"
+                     ))
                 .Initialise(m_DefaultSystems);
-            Assert.IsTrue(World.AllWorlds.Any(x=>x.Name=="Test A"));
+            Assert.IsTrue(World.AllWorlds.Any(x => x.Name == "Test A"));
             Assert.AreSame("Test A", World.Active.Name);
             Assert.AreEqual(10, World.Active.Systems.Count());
         }
@@ -49,13 +50,15 @@ namespace Tests
         [Test]
         public void Should_Return_Null_When_Creating_A_New_Default_World()
         {
-            Assert.IsNull(new Initialiser(
-                m_FakeCWB,
-                true,
-                new System.Collections.Generic.List<CustomWorldBootstrap.WorldOption> {
-                    new CustomWorldBootstrap.WorldOption("Test A")
-                },
-                "Test A")
+            Assert.IsNull(
+                new Initialiser(
+                    new FakeCustomWorldBootstrap(
+                        new System.Collections.Generic.List<CustomWorldBootstrap.WorldOption> {
+                            new CustomWorldBootstrap.WorldOption("Test A")
+                        },
+                        true,
+                        "Test A"
+                        ))
                 .Initialise(m_DefaultSystems));
         }
     }

--- a/Assets/Tests/EmptyWorldTests.cs
+++ b/Assets/Tests/EmptyWorldTests.cs
@@ -22,7 +22,7 @@ namespace Tests
                 m_InitialSystems.Add(s.GetType());
             }
 
-            new Initialiser(m_FakeCWB, true, new List<CustomWorldBootstrap.WorldOption>() { new CustomWorldBootstrap.WorldOption(WORLDNAME) }).Initialise(DefaultSystems);
+            new Initialiser(new FakeCustomWorldBootstrap(new List<CustomWorldBootstrap.WorldOption>() { new CustomWorldBootstrap.WorldOption(WORLDNAME) })).Initialise(DefaultSystems);
         }
 
         [Test]

--- a/Assets/Tests/PostWorldInitializeTests.cs
+++ b/Assets/Tests/PostWorldInitializeTests.cs
@@ -1,7 +1,7 @@
-﻿using NUnit.Framework;
+﻿using CustomWorldBoostrapInternal;
+using NUnit.Framework;
 using System.Collections.Generic;
 using Unity.Entities;
-using CustomWorldBoostrapInternal;
 
 
 namespace Tests
@@ -17,11 +17,11 @@ namespace Tests
         protected override void OneTimeSetup()
         {
             base.OneTimeSetup();
-            new Initialiser(m_FakeCWB, true, new List<CustomWorldBootstrap.WorldOption>()
+            new Initialiser(new FakeCustomWorldBootstrap(new List<CustomWorldBootstrap.WorldOption>()
             {
                 new CustomWorldBootstrap.WorldOption(WorldAName) { OnInitialize = PostWorldAIntialize },
                 new CustomWorldBootstrap.WorldOption(WorldBName) { OnInitialize = PostWorldBIntialize }
-            }).Initialise(m_DefaultSystems);
+            })).Initialise(m_DefaultSystems);
         }
 
         [Test]

--- a/Assets/Tests/Resources/FakeCustomWorldBootstrap.cs
+++ b/Assets/Tests/Resources/FakeCustomWorldBootstrap.cs
@@ -1,13 +1,33 @@
-﻿using System;
+﻿using CustomWorldBoostrapInternal;
+using System;
 using System.Collections.Generic;
-using CustomWorldBoostrapInternal;
 
 namespace Tests
 {
     public class FakeCustomWorldBootstrap : ICustomWorldBootstrap
     {
+
+        public FakeCustomWorldBootstrap(
+            List<CustomWorldBootstrap.WorldOption> worldOptions = null,
+            bool createDefaultWorld = true,
+            string defaultWorldName = "")
+        {
+            if (worldOptions != null)
+            {
+                WorldOptions.AddRange(worldOptions);
+            }
+
+            CreateDefaultWorld = createDefaultWorld;
+            DefaultWorldName = defaultWorldName;
+        }
         public List<Type> Alterations = new List<Type>();
         public bool PostInitializeRan = false;
+
+        public bool CreateDefaultWorld { get; set; }
+        public string DefaultWorldName { get; set; }
+
+        public List<CustomWorldBootstrap.WorldOption> WorldOptions { get; } = new List<CustomWorldBootstrap.WorldOption>();
+
         public List<Type> PostInitialize(List<Type> systems)
         {
             PostInitializeRan = true;

--- a/Assets/Tests/Resources/TestComponentSystems.cs
+++ b/Assets/Tests/Resources/TestComponentSystems.cs
@@ -95,6 +95,7 @@ namespace Tests
     public class Test6_Group: ComponentSystemGroup
     {
         public string UpdateOrder = "";
+        public string UpdateOrderB = "";
     }
 
     [DisableAutoCreation]
@@ -134,6 +135,42 @@ namespace Tests
             World.GetExistingSystem<Test6_Group>().UpdateOrder += "3";
         }
     }
+
+    [DisableAutoCreation]
+    [CreateInWorld("Test6 World")]
+    [UpdateAfter(typeof(Test6_System2b))]
+    public class Test6_System1b : UpdateableSystem
+    {
+        protected override void OnUpdate()
+        {
+            base.OnUpdate();
+            World.GetExistingSystem<Test6_Group>().UpdateOrderB += "1";
+        }
+    }
+
+    [DisableAutoCreation]
+    [CreateInWorld("Test6 World")]
+    public class Test6_System2b : UpdateableSystem
+    {
+        protected override void OnUpdate()
+        {
+            base.OnUpdate();
+            World.GetExistingSystem<Test6_Group>().UpdateOrderB += "2";
+        }
+    }
+
+    [DisableAutoCreation]
+    [CreateInWorld("Test6 World")]
+    [UpdateBefore(typeof(Test6_System2b))]
+    public class Test6_System3b : UpdateableSystem
+    {
+        protected override void OnUpdate()
+        {
+            base.OnUpdate();
+            World.GetExistingSystem<Test6_Group>().UpdateOrderB += "3";
+        }
+    }
+
 
     [DisableAutoCreation]
     public class Test7_System : UpdateableSystem, ITest7

--- a/Assets/Tests/Resources/TestComponentSystems.cs
+++ b/Assets/Tests/Resources/TestComponentSystems.cs
@@ -111,4 +111,10 @@ namespace Tests
     {
 
     }
+    [DisableAutoCreation]
+    public class Test7_System : UpdateableSystem, ITest7
+    {
+
+    }
+    public interface ITest7 { }
 }

--- a/Assets/Tests/Resources/TestComponentSystems.cs
+++ b/Assets/Tests/Resources/TestComponentSystems.cs
@@ -90,27 +90,51 @@ namespace Tests
 
     }
 
+    [DisableAutoCreation]
+    [CreateInWorld("Test6 World")]
+    public class Test6_Group: ComponentSystemGroup
+    {
+        public string UpdateOrder = "";
+    }
 
     [DisableAutoCreation]
     [CreateInWorld("Test6 World")]
+    [UpdateInGroup(typeof(Test6_Group))]
     [UpdateAfter(typeof(Test6_System2))]
     public class Test6_System1 : UpdateableSystem
     {
-
+        protected override void OnUpdate()
+        {
+            base.OnUpdate();
+            World.GetExistingSystem<Test6_Group>().UpdateOrder += "1";
+        }
     }
+
     [DisableAutoCreation]
+    [UpdateInGroup(typeof(Test6_Group))]
     [CreateInWorld("Test6 World")]
     public class Test6_System2 : UpdateableSystem
     {
-
+        protected override void OnUpdate()
+        {
+            base.OnUpdate();
+            World.GetExistingSystem<Test6_Group>().UpdateOrder += "2";
+        }
     }
+
     [DisableAutoCreation]
+    [UpdateInGroup(typeof(Test6_Group))]
     [CreateInWorld("Test6 World")]
     [UpdateBefore(typeof(Test6_System2))]
     public class Test6_System3 : UpdateableSystem
     {
-
+        protected override void OnUpdate()
+        {
+            base.OnUpdate();
+            World.GetExistingSystem<Test6_Group>().UpdateOrder += "3";
+        }
     }
+
     [DisableAutoCreation]
     public class Test7_System : UpdateableSystem, ITest7
     {

--- a/Assets/Tests/UpdateOrderTests.cs
+++ b/Assets/Tests/UpdateOrderTests.cs
@@ -1,0 +1,37 @@
+﻿using NUnit.Framework;
+using Unity.Entities;
+using CustomWorldBoostrapInternal;
+
+
+namespace Tests
+{
+    public class UpdateOrderTests : MyTestFixture
+    {
+        private const string WORLDNAME = "Test6 World";
+
+        [OneTimeSetUp]
+        protected override void OneTimeSetup()
+        {
+            base.OneTimeSetup();
+            m_DefaultSystems.Add(typeof(Test6_Group));
+            m_DefaultSystems.Add(typeof(Test6_System1));
+            m_DefaultSystems.Add(typeof(Test6_System2));
+            m_DefaultSystems.Add(typeof(Test6_System3));
+            var newSystems = new Initialiser(m_FakeCWB).Initialise(m_DefaultSystems);
+        }
+
+        [Test]
+        public void Creates_Custom_World()
+        {
+            Assert.IsTrue(WorldExists(WORLDNAME));
+        }
+
+        [Test]
+        public void System_Updates_In_Order()
+        {
+            var world = GetWorld(WORLDNAME);
+            World.Active.GetExistingSystem<SimulationSystemGroup>().Update();
+            Assert.AreEqual("321", world.GetExistingSystem<Test6_Group>().UpdateOrder);
+        }
+    }
+}

--- a/Assets/Tests/UpdateOrderTests.cs
+++ b/Assets/Tests/UpdateOrderTests.cs
@@ -17,9 +17,14 @@ namespace Tests
             m_DefaultSystems.Add(typeof(Test6_System1));
             m_DefaultSystems.Add(typeof(Test6_System2));
             m_DefaultSystems.Add(typeof(Test6_System3));
+            m_DefaultSystems.Add(typeof(Test6_System1b));
+            m_DefaultSystems.Add(typeof(Test6_System2b));
+            m_DefaultSystems.Add(typeof(Test6_System3b));
             var newSystems = new Initialiser(m_FakeCWB).Initialise(m_DefaultSystems);
-        }
 
+            World.Active.GetExistingSystem<SimulationSystemGroup>().Update();
+        }
+       
         [Test]
         public void Creates_Custom_World()
         {
@@ -27,11 +32,17 @@ namespace Tests
         }
 
         [Test]
-        public void System_Updates_In_Order()
+        public void System_Update_In_Order()
         {
             var world = GetWorld(WORLDNAME);
-            World.Active.GetExistingSystem<SimulationSystemGroup>().Update();
             Assert.AreEqual("321", world.GetExistingSystem<Test6_Group>().UpdateOrder);
+        }
+
+        [Test]
+        public void System_In_Root_SimGroup_Update_In_Order()
+        {
+            var world = GetWorld(WORLDNAME);
+            Assert.AreEqual("321", world.GetExistingSystem<Test6_Group>().UpdateOrderB);
         }
     }
 }


### PR DESCRIPTION
* Added ability to include worlds based on custom include list.
This enables you to define a custom query as to which systems to include on a per world basis.
Uses an additional WorldOption `Func<List<Type>, List<Type>>CustomIncludeQuery` that can be used to return systems to include in world. An example would be to include all systems that implement a specific interface.
* DefaultWorldName default is now blank. Should only set to change default world.
* SortOrderUpdate now called when adding to a custom SystemComponentGoup
* Added update order tests
* Adjusted internal interface for more reliable testing 
* Updated readme
